### PR TITLE
Fixes Vagrantfile causing issues with Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,13 @@ require 'yaml'
 
 # Read yaml node definitions to create
 # **Update environment.yml to reflect any changes
-environment = YAML.load_file(File.join(File.dirname(__FILE__), ENV['SCENARIO']))
-nodes = environment['nodes']
+if ENV['SCENARIO'].nil?
+  environment = {}
+  nodes = []
+else
+  environment = YAML.load_file(File.join(File.dirname(__FILE__), ENV['SCENARIO']))
+  nodes = environment['nodes']
+end
 
 # Define global variables
 #


### PR DESCRIPTION
When a scenario has not been loaded, the following error occurs:

Line number: 14
Message: TypeError: no implicit conversion of nil into String

Fixes #12